### PR TITLE
New testnet re-deployment changes

### DIFF
--- a/jobs/mantis-qa-load.nix
+++ b/jobs/mantis-qa-load.nix
@@ -413,11 +413,7 @@ let
         secret = key: ''{{ with secret "${key}" }}{{.Data.data.value}}{{end}}'';
       in [
         {
-          # FIXME: this previously extended "${mantis-faucet}/conf/testnet-internal.conf", but mantis-faucet is undefined, I might have not fully fixed while changing this
           data = ''
-            include "${faucet}/conf/testnet-internal.conf"
-            mantis.blockchains.testnet-internal.custom-genesis-file = "{{ env "NOMAD_TASK_DIR" }}/genesis.json"
-
             faucet {
               # Base directory where all the data used by the faucet is stored
               datadir = "/local/mantis-faucet"
@@ -513,18 +509,6 @@ let
                 }
               }
             }
-
-            mantis.blockchains.testnet-internal.bootstrap-nodes = [
-              {{ range service "${namespace}-mantis-miner" -}}
-                "enode://  {{- with secret (printf "kv/data/nomad-cluster/${namespace}/%s/enode-hash" .ServiceMeta.Name) -}}
-                  {{- .Data.data.value -}}
-                  {{- end -}}@{{ .Address }}:{{ .Port }}",
-              {{ end -}}
-            ]
-
-            mantis.client-id = "${faucetName}"
-            mantis.metrics.enabled = true
-            mantis.metrics.port = {{ env "NOMAD_PORT_metrics" }}
           '';
           changeMode = "noop";
           destination = "local/faucet.conf";

--- a/jobs/mantis-qa-load.nix
+++ b/jobs/mantis-qa-load.nix
@@ -413,8 +413,9 @@ let
         secret = key: ''{{ with secret "${key}" }}{{.Data.data.value}}{{end}}'';
       in [
         {
+          # FIXME: this previously extended "${mantis-faucet}/conf/testnet-internal.conf", but mantis-faucet is undefined, I might have not fully fixed while changing this
           data = ''
-            include "${mantis-faucet}/conf/testnet-internal.conf"
+            include "${faucet}/conf/testnet-internal.conf"
             mantis.blockchains.testnet-internal.custom-genesis-file = "{{ env "NOMAD_TASK_DIR" }}/genesis.json"
 
             faucet {

--- a/jobs/mantis.nix
+++ b/jobs/mantis.nix
@@ -515,7 +515,7 @@ let
 
               # Wallet address used to send transactions from
               wallet-address =
-                {{- with secret "kv/nomad-cluster/${namespace}/${namespace}-mantis-1/coinbase" -}}
+                {{- with secret "kv/nomad-cluster/${namespace}/mantis-1/coinbase" -}}
                   "{{.Data.data.value}}"
                 {{- end }}
 
@@ -611,7 +611,7 @@ let
         genesisJson
         {
           data = ''
-            {{- with secret "kv/data/nomad-cluster/${namespace}/${namespace}-mantis-1/account" -}}
+            {{- with secret "kv/data/nomad-cluster/${namespace}/mantis-1/account" -}}
             {{.Data.data | toJSON }}
             {{- end -}}
           '';
@@ -619,7 +619,7 @@ let
         }
         {
           data = ''
-            COINBASE={{- with secret "kv/data/nomad-cluster/${namespace}/${namespace}-mantis-1/coinbase" -}}{{ .Data.data.value }}{{- end -}}
+            COINBASE={{- with secret "kv/data/nomad-cluster/${namespace}/mantis-1/coinbase" -}}{{ .Data.data.value }}{{- end -}}
           '';
           destination = "secrets/env";
           env = true;

--- a/jobs/mantis.nix
+++ b/jobs/mantis.nix
@@ -18,6 +18,7 @@ let
     let secret = key: ''{{ with secret "${key}" }}{{.Data.data.value}}{{end}}'';
     in [
       {
+        # FIXME: pow-target-time was only temporarily changed here, should be included on the default testnet-internal on next version of mantis
         data = ''
           include "${mantis}/conf/testnet-internal.conf"
 
@@ -43,6 +44,8 @@ let
           mantis.network.rpc.http.port = {{ env "NOMAD_PORT_rpc" }}
           mantis.network.server-address.port = {{ env "NOMAD_PORT_server" }}
           mantis.blockchains.testnet-internal.custom-genesis-file = "{{ env "NOMAD_TASK_DIR" }}/genesis.json"
+
+          mantis.blockchains.testnet-internal.pow-target-time = 30 seconds
         '';
         destination = "local/mantis.conf";
         changeMode = "noop";
@@ -273,6 +276,7 @@ let
 
       templates = [
         {
+          # FIXME: pow-target-time was only temporarily changed here, should be included on the default testnet-internal on next version of mantis
           data = ''
             include "${mantis}/conf/testnet-internal.conf"
 
@@ -297,6 +301,8 @@ let
             mantis.network.rpc.http.port = {{ env "NOMAD_PORT_rpc" }}
             mantis.network.server-address.port = {{ env "NOMAD_PORT_server" }}
             mantis.blockchains.testnet-internal.custom-genesis-file = "{{ env "NOMAD_TASK_DIR" }}/genesis.json"
+
+            mantis.blockchains.testnet-internal.pow-target-time = 30 seconds
           '';
           changeMode = "restart";
           destination = "local/mantis.conf";

--- a/jobs/mantis.nix
+++ b/jobs/mantis.nix
@@ -509,9 +509,6 @@ let
       in [
         {
           data = ''
-            include "${mantis-faucet}/conf/testnet-internal.conf"
-            mantis.blockchains.testnet-internal.custom-genesis-file = "{{ env "NOMAD_TASK_DIR" }}/genesis.json"
-
             faucet {
               # Base directory where all the data used by the faucet is stored
               datadir = "/local/mantis-faucet"
@@ -607,18 +604,6 @@ let
                 }
               }
             }
-
-            mantis.blockchains.testnet-internal.bootstrap-nodes = [
-              {{ range service "${namespace}-mantis-miner" -}}
-                "enode://  {{- with secret (printf "kv/data/nomad-cluster/${namespace}/%s/enode-hash" .ServiceMeta.Name) -}}
-                  {{- .Data.data.value -}}
-                  {{- end -}}@{{ .Address }}:{{ .Port }}",
-              {{ end -}}
-            ]
-
-            mantis.client-id = "${faucetName}"
-            mantis.metrics.enabled = true
-            mantis.metrics.port = {{ env "NOMAD_PORT_metrics" }}
           '';
           changeMode = "noop";
           destination = "local/faucet.conf";

--- a/overlay.nix
+++ b/overlay.nix
@@ -10,14 +10,14 @@ in {
   # The branch was `chore/update-sbt-add-nix`, for future reference.
   mantis-source = builtins.fetchGit {
     url = "https://github.com/input-output-hk/mantis";
-    rev = "df2916bccd53b2ccc5c3758e5aa7f272c6fbb4fe";
+    rev = "dcb6d7b714bc1e23f75dd3e62365b316dab68ec3";
     ref = "develop";
     submodules = true;
   };
 
   mantis-faucet-source = builtins.fetchGit {
     url = "https://github.com/input-output-hk/mantis";
-    rev = "df2916bccd53b2ccc5c3758e5aa7f272c6fbb4fe";
+    rev = "dcb6d7b714bc1e23f75dd3e62365b316dab68ec3";
     ref = "develop";
     submodules = true;
   };
@@ -29,6 +29,10 @@ in {
 
   mantis-faucet = import final.mantis-faucet-source { inherit system; };
 
+  # Any:
+  # - run of this command with a parameter different than the testnet (currently 10)
+  # - change in the genesis file here
+  # Requires an update on the mantis repository and viceversa
   generate-mantis-keys = let
     mantisConfigJson = {
       mantis = {
@@ -119,10 +123,10 @@ in {
     for count in $(seq "$desired"); do
       keyFile="secrets/mantis-$count.key"
       coinbaseFile="secrets/mantis-$count.coinbase"
-      secretKeyPath="kv/nomad-cluster/$prefix/testnet-mantis-$count/secret-key"
-      hashKeyPath="kv/nomad-cluster/$prefix/testnet-mantis-$count/enode-hash"
-      coinbasePath="kv/nomad-cluster/$prefix/testnet-mantis-$count/coinbase"
-      accountPath="kv/nomad-cluster/$prefix/testnet-mantis-$count/account"
+      secretKeyPath="kv/nomad-cluster/$prefix/mantis-$count/secret-key"
+      hashKeyPath="kv/nomad-cluster/$prefix/mantis-$count/enode-hash"
+      coinbasePath="kv/nomad-cluster/$prefix/mantis-$count/coinbase"
+      accountPath="kv/nomad-cluster/$prefix/mantis-$count/account"
       genesisPath="kv/nomad-cluster/$prefix/genesis"
 
       hashKey="$(vault kv get -field value "$hashKeyPath" || true)"


### PR DESCRIPTION
# Changes

- Updates mantis and faucet (backend) versions to latest develop
- Changes block rate to 30 seconds per block. This should be removed once updated on mantis repository: https://github.com/input-output-hk/mantis/pull/801
- Fixes unupdated paths on generate-mantis-keys script
- Fixes (maybe wrongly) undefined variable on mantis-qa-load.nix