### PR TITLE
Reflect ETCM-331 faucet config changes

### DIFF
--- a/jobs/mantis-qa-fastsync.nix
+++ b/jobs/mantis-qa-fastsync.nix
@@ -590,6 +590,19 @@ let
                     # Domains allowed to query RPC endpoint. Use "*" to enable requests from
                     # any domain.
                     cors-allowed-origins = "*"
+
+                    # Rate Limit for JSON-RPC requests
+                    # Limits the amount of request the same ip can perform in a given amount of time
+                    rate-limit {
+                      # If enabled, restrictions are applied
+                      enabled = false
+
+                      # Time that should pass between requests
+                      min-request-interval = 10.seconds
+
+                      # Size of stored timestamps for requests made from each ip
+                      latest-timestamp-cache-size = 1024
+                    }
                   }
 
                   ipc {

--- a/jobs/mantis-qa-load.nix
+++ b/jobs/mantis-qa-load.nix
@@ -601,6 +601,19 @@ let
                     # Domains allowed to query RPC endpoint. Use "*" to enable requests from
                     # any domain.
                     cors-allowed-origins = "*"
+
+                    # Rate Limit for JSON-RPC requests
+                    # Limits the amount of request the same ip can perform in a given amount of time
+                    rate-limit {
+                      # If enabled, restrictions are applied
+                      enabled = false
+
+                      # Time that should pass between requests
+                      min-request-interval = 10.seconds
+
+                      # Size of stored timestamps for requests made from each ip
+                      latest-timestamp-cache-size = 1024
+                    }
                   }
 
                   ipc {

--- a/jobs/mantis.nix
+++ b/jobs/mantis.nix
@@ -626,6 +626,19 @@ let
                     # Domains allowed to query RPC endpoint. Use "*" to enable requests from
                     # any domain.
                     cors-allowed-origins = "*"
+
+                    # Rate Limit for JSON-RPC requests
+                    # Limits the amount of request the same ip can perform in a given amount of time
+                    rate-limit {
+                      # If enabled, restrictions are applied
+                      enabled = false
+
+                      # Time that should pass between requests
+                      min-request-interval = 10.seconds
+
+                      # Size of stored timestamps for requests made from each ip
+                      latest-timestamp-cache-size = 1024
+                    }
                   }
 
                   ipc {

--- a/overlay.nix
+++ b/overlay.nix
@@ -10,14 +10,14 @@ in {
   # The branch was `chore/update-sbt-add-nix`, for future reference.
   mantis-source = builtins.fetchGit {
     url = "https://github.com/input-output-hk/mantis";
-    rev = "7031c7f3f9e065e51317eacdce59175b15c175f9";
+    rev = "4fc1d4ab5396f206319387e0283d597ea390f6b8";
     ref = "develop";
     submodules = true;
   };
 
   mantis-faucet-source = builtins.fetchGit {
     url = "https://github.com/input-output-hk/mantis";
-    rev = "7031c7f3f9e065e51317eacdce59175b15c175f9";
+    rev = "4fc1d4ab5396f206319387e0283d597ea390f6b8";
     ref = "develop";
     submodules = true;
   };


### PR DESCRIPTION
## Description

- Reflect ETCM-331 faucet config changes
- Update Mantis version to latest develop

In order to not block the activity generator on our cluster, the restriction is left turned off till we can do an e2e test with the faucet frontend