### PR TITLE
Checkpointing and other updates

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -16,7 +16,7 @@ jobs:
       run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
     - uses: cachix/install-nix-action@v12
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-3.0pre20200820_4d77513/install
+        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
         extra_nix_config: |
           experimental-features = nix-command flakes
     - uses: cachix/cachix-action@v8

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ secrets/
 .direnv/
 cert.config
 config.tf.json
-result/
+result*

--- a/contrib/dashboards/morpho.json
+++ b/contrib/dashboards/morpho.json
@@ -15,8 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 137,
-  "iteration": 1609948351949,
+  "iteration": 1611171869203,
   "links": [],
   "panels": [
     {
@@ -936,6 +935,107 @@
           "show": true
         },
         {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "VictoriaMetrics",
+      "description": "Total amount of live data in the heap from the last GC, field gcdetails_live_bytes from Ghc.Stats",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "hiddenSeries": false,
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "morpho_live_bytes_gauge{namespace=\"$namespace\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{client_id}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Live Bytes",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:253",
+          "decimals": null,
+          "format": "bytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:254",
           "format": "short",
           "label": null,
           "logBase": 1,

--- a/docker/morpho.nix
+++ b/docker/morpho.nix
@@ -1,55 +1,32 @@
-{ lib, buildLayeredImage, mkEnv, morpho-node, coreutils, gnused, gnugrep, procps
-, writeShellScript, jq, diffutils }:
+{ lib, buildLayeredImage, mkEnv, morpho-node, coreutils, bashInteractive
+, writeShellScript, iana-etc, runCommandNoCC }:
 let
   run-morpho-node = writeShellScript "morpho-node" ''
-    set -exuo pipefail
-
-    cd "$NOMAD_TASK_DIR"
-    name="morpho-checkpoint-node"
-
-    cp morpho-topology.json running-morpho-topology.json
-
-    (
-      while true; do
-        while diff -u running-morpho-topology.json morpho-topology.json > /dev/stderr; do
-          sleep 300
-        done
-
-        if ! diff -u running-morpho-topology.json morpho-topology.json > /dev/stderr; then
-          cp morpho-topology.json running-morpho-topology.json
-          pkill "$name" || true
-        fi
-      done
-    ) &
-
-    starts=0
-    while true; do
-      starts="$((starts+1))"
-      echo "Start Number $starts" > /dev/stderr
-      morpho-checkpoint-node \
-        --topology "$NOMAD_TASK_DIR/running-morpho-topology.json" \
-        --database-path /local/db \
-        --port "$NOMAD_PORT_morpho" \
-        --config "$NOMAD_TASK_DIR/morpho-config.yaml" \
-        --socket-dir "$NOMAD_TASK_DIR/socket" \
-        "$@" || true
-      sleep 10
-    done
+    morpho-checkpoint-node \
+      --topology "$NOMAD_TASK_DIR/morpho-topology.json" \
+      --database-path /local/db \
+      --port "$NOMAD_PORT_morpho" \
+      --config "$NOMAD_TASK_DIR/morpho-config.yaml" \
+      --socket-dir "$NOMAD_TASK_DIR/socket" \
+      "$@"
+  '';
+  # Needed for DNS to work
+  etcRoot = runCommandNoCC "etc" {} ''
+    mkdir -p $out/etc
+    ln -s ${iana-etc}/etc/services $out/etc/services
   '';
 in {
   morpho = buildLayeredImage {
     name = "docker.mantis.ws/morpho-node";
+    contents = [ etcRoot ];
     config = {
       Entrypoint = [ run-morpho-node ];
       Env = mkEnv {
         PATH = lib.makeBinPath [
-          coreutils
-          gnugrep
-          gnused
           morpho-node
-          jq
-          procps
-          diffutils
+
+          bashInteractive
+          coreutils
         ];
       };
     };

--- a/flake.lock
+++ b/flake.lock
@@ -204,16 +204,15 @@
         "utils": "utils_4"
       },
       "locked": {
-        "lastModified": 1609763930,
-        "narHash": "sha256-LQUICRookDPYCizNYgTpuHpwRYnsqOR0CC4K/sas12A=",
+        "lastModified": 1611853719,
+        "narHash": "sha256-JaBjm4lupDunk4iAHjiq49hHOIQv9dA8ujtsX64+2Zo=",
         "owner": "input-output-hk",
         "repo": "ECIP-Checkpointing",
-        "rev": "387971dd1c98154488cd99d929b9462becb29d47",
+        "rev": "72f7c3136b73718695c94a0a874e94c4bc61203e",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "master",
         "repo": "ECIP-Checkpointing",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -8,23 +8,21 @@
           "bitte-cli",
           "crystal"
         ],
-        "inclusive": "inclusive_2",
-        "nixpkgs": [
-          "bitte",
-          "bitte-cli",
-          "nixpkgs"
-        ],
+        "inclusive": "inclusive",
+        "levant-source": "levant-source",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-terraform": "nixpkgs-terraform",
+        "nomad-source": "nomad-source",
         "ops-lib": "ops-lib",
         "terranix": "terranix",
         "utils": "utils_3"
       },
       "locked": {
-        "lastModified": 1610386329,
-        "narHash": "sha256-iFnuPB4SQl6z+C4xId48sMi/UrrS+M//IGDl1YWHryw=",
+        "lastModified": 1611841266,
+        "narHash": "sha256-e7INx5f6fVDyw+VOTUJCKJV7/oa7K3cg/5zjA4ULVFo=",
         "owner": "input-output-hk",
         "repo": "bitte",
-        "rev": "8c822e79e3a4d6e07f8ccbd05aa809e41d5f3142",
+        "rev": "642b787ef042baec55d0808ff5fb0e02eb6d74e1",
         "type": "github"
       },
       "original": {
@@ -36,16 +34,16 @@
     "bitte-cli": {
       "inputs": {
         "crystal": "crystal",
-        "inclusive": "inclusive",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs/nixos-rebuild-no-systemctl": "nixpkgs/nixos-rebuild-no-systemctl",
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1606386177,
-        "narHash": "sha256-r0l2phaLS+7iZ9VpDjzAhlb9AjcL+hAGDJBvdfh86Vc=",
+        "lastModified": 1610042979,
+        "narHash": "sha256-TJAxkcaRYEpsfmiueNh9i9Dx3qeYBKIwEQdFhSA0Kfw=",
         "owner": "input-output-hk",
         "repo": "bitte-cli",
-        "rev": "9355abbdcee3ea01f5267d786c0cca8f614fb36e",
+        "rev": "416ea33e32f00a2e2b6506283c6a217d519042f3",
         "type": "github"
       },
       "original": {
@@ -60,11 +58,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1602755823,
-        "narHash": "sha256-6MYxvT5e1xT4Kb1TKzk4AO3EefQTJ+juj38KUHV+NPI=",
+        "lastModified": 1608083084,
+        "narHash": "sha256-zF7F++nIfSA+27qLlJOGSg/IiAsBNBK7Xnm8wKh324I=",
         "owner": "kreisys",
         "repo": "crystal",
-        "rev": "6718e4f851347ce34d8fbabf516c6a0da85966f0",
+        "rev": "5fa991b1f0ce9aa8a0dc8226a0af8d75ae9330ae",
         "type": "github"
       },
       "original": {
@@ -137,28 +135,27 @@
         "type": "github"
       }
     },
-    "inclusive_2": {
-      "inputs": {
-        "stdlib": "stdlib_2"
-      },
+    "levant-source": {
+      "flake": false,
       "locked": {
-        "lastModified": 1594133516,
-        "narHash": "sha256-4Z9XU8QRmTU7LldCxwRqkEH5pHJwgW8XmMvqu4t2DEg=",
-        "owner": "input-output-hk",
-        "repo": "nix-inclusive",
-        "rev": "11d05e4f1ca04fd250a9734e27970ad73bbd872d",
+        "lastModified": 1607520931,
+        "narHash": "sha256-yKLT61uCcgkUWPtaOmruy2uXhJ/ON94QqhoYg2Gulww=",
+        "owner": "hashicorp",
+        "repo": "levant",
+        "rev": "05c6c36fdf24237af32a191d2b14756dbb2a4f24",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "nix-inclusive",
+        "owner": "hashicorp",
+        "repo": "levant",
+        "rev": "05c6c36fdf24237af32a191d2b14756dbb2a4f24",
         "type": "github"
       }
     },
     "mantis-explorer": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1606398004,
@@ -177,7 +174,7 @@
     "mantis-faucet-web": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1607432251,
@@ -219,11 +216,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1602739928,
-        "narHash": "sha256-mpfoeHf9QaMPNurSYeSkxerDfs6Fj7HDElSMXDaTOPQ=",
+        "lastModified": 1608073274,
+        "narHash": "sha256-2g5soirxH22xi/2iIzTOtpdRYXSSI4x+OYsDM9Nc4ms=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2a4607f44222a92b8a44e6e1dac715e7eca04239",
+        "rev": "5d5e970ce04933576957dfbf99cb7d4c1802c60d",
         "type": "github"
       },
       "original": {
@@ -247,7 +244,39 @@
         "type": "github"
       }
     },
+    "nixpkgs/nixos-rebuild-no-systemctl": {
+      "locked": {
+        "lastModified": 1603912078,
+        "narHash": "sha256-T6zhWX0PG6J+yWXGjG3D7khiTeHzLu0pQ2MTHGwRz2A=",
+        "owner": "kreisys",
+        "repo": "nixpkgs",
+        "rev": "b02d5ae5a23b0532023453e5c0e861fd507b726c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kreisys",
+        "ref": "nixos-rebuild-no-systemctl",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1609867866,
+        "narHash": "sha256-ITciATW51g/VqL4CTCh74Cu/wqIztkoJNZJxqj2vEMs=",
+        "owner": "Nixos",
+        "repo": "nixpkgs",
+        "rev": "4a75ca4a4e7d14e7b0b0230b3ea57b5bd7c16218",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Nixos",
+        "ref": "nixos-20.09",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1595425804,
         "narHash": "sha256-RM8fHq1PoN8HHVRPKIjYLrXq54Z18iVodQrwxmH/J3g=",
@@ -258,12 +287,12 @@
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "b8c367a7bd05e3a514c2b057c09223c74804a21b",
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1603802751,
         "narHash": "sha256-K3CeF3CYy7LCu0J1NnSdo77oVIkcwf0cXDAA/HFjP58=",
@@ -277,7 +306,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1605721780,
         "narHash": "sha256-MhaNS4HGHcOCwW+HadSxustHTzD1LWznh584eYBvJ5Q=",
@@ -288,6 +317,23 @@
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
+      }
+    },
+    "nomad-source": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611841139,
+        "narHash": "sha256-6tgqFnRB9efZ+8wab7lyTHLcXmLd7JD5chq83p+WXns=",
+        "owner": "manveru",
+        "repo": "nomad",
+        "rev": "079e7e20582cdba660678f6a86bf96f93c3db2da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "manveru",
+        "ref": "release-1.0.2",
+        "repo": "nomad",
+        "type": "github"
       }
     },
     "ops-lib": {
@@ -365,21 +411,6 @@
         "type": "github"
       }
     },
-    "stdlib_2": {
-      "locked": {
-        "lastModified": 1590026685,
-        "narHash": "sha256-E5INrVvYX/P/UpcoUFDAsuHem+lsqT+/teBs9O7oc9Q=",
-        "owner": "manveru",
-        "repo": "nix-lib",
-        "rev": "99088cf7febcdb21afd375a335dcafa959bef3ed",
-        "type": "github"
-      },
-      "original": {
-        "owner": "manveru",
-        "repo": "nix-lib",
-        "type": "github"
-      }
-    },
     "terranix": {
       "flake": false,
       "locked": {
@@ -399,30 +430,30 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1601282935,
-        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
-        "owner": "numtide",
+        "lastModified": 1608083023,
+        "narHash": "sha256-0OeP7iDNsX/9rasi04wI7q8S3VO0gVxQKXx25Re3ER0=",
+        "owner": "kreisys",
         "repo": "flake-utils",
-        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "rev": "981afef38507fac81120aa0c0bc4d37e4e3a2019",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
+        "owner": "kreisys",
         "repo": "flake-utils",
         "type": "github"
       }
     },
     "utils_2": {
       "locked": {
-        "lastModified": 1590791977,
-        "narHash": "sha256-l26u9vRsdV9jkoBGlzFxTKLKtrZ38xCMZIG9h9ibFjQ=",
-        "owner": "numtide",
+        "lastModified": 1608409263,
+        "narHash": "sha256-L7gMksy7VR+GcySJhBFnjzO+GsB/BZje+1hvglbhyZk=",
+        "owner": "kreisys",
         "repo": "flake-utils",
-        "rev": "4fbce19a7a9647154a35f0e856d52171c41e14a4",
+        "rev": "b83c460130ee151d6b91b72dd6261fe53c8e4a79",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
+        "owner": "kreisys",
         "repo": "flake-utils",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     utils.url = "github:numtide/flake-utils";
     ops-lib.url = "github:input-output-hk/ops-lib/zfs-image?dir=zfs";
     inclusive.follows = "bitte/inclusive";
-    morpho-node.url = "github:input-output-hk/ECIP-Checkpointing/master";
+    morpho-node.url = "github:input-output-hk/ECIP-Checkpointing";
     mantis-explorer.url = "github:input-output-hk/mantis-explorer";
     mantis-faucet-web.url =
       "github:input-output-hk/mantis-faucet-web/nix-build";

--- a/jobs/mantis-staging.nix
+++ b/jobs/mantis-staging.nix
@@ -28,6 +28,7 @@ let
     inherit namespace morpho-source vault dockerImages;
     name = "obft-node-${toString n}";
     nodeNumber = n;
+    nodeCount = amountOfMorphoNodes;
   });
 
   mkMantis = { name, resources, count ? 1, templates, serviceName, tags ? [ ]
@@ -935,7 +936,7 @@ in {
       mkMorpho = import ./tasks/morpho.nix;
       generateMorphoTaskGroup = nbNodes: node:
         lib.nameValuePair node.name (lib.recursiveUpdate (mkPassive 1)
-          (mkMorpho (node // { inherit nbNodes; })));
+          (mkMorpho (node // { inherit lib nbNodes; })));
       morphoTaskGroups =
         map (generateMorphoTaskGroup (builtins.length morphoNodes)) morphoNodes;
     in lib.listToAttrs morphoTaskGroups;


### PR DESCRIPTION
Contains a number of changes:
- Updates morpho to contain https://github.com/input-output-hk/ECIP-Checkpointing/commit/a44a161ff214a9add298980c746b14a8677098b9 which adds a prometheus gauge for memory usage.
- Adds a new panel to the grafana dashboard for showing the gauge value over time
- Updates bitte to latest master, which notably includes https://github.com/input-output-hk/bitte/pull/18 to fix the skopeo docker pushing
- Reworks how the morpho topology is discovered: Now uses SRV records provided by consul, relying on https://github.com/input-output-hk/bitte/pull/17 and https://github.com/input-output-hk/ECIP-Checkpointing/pull/14. With this, the topology file can be static and doesn't need to be changed, which also means that nodes don't need to be restarted whenever the topology changes. In staging deployments this worked really well, with nodes connecting to each other very quickly and reliably. It also simplifies the deployment code a bunch.
- Updates the Nix version used for GitHub Actions to a working version so that CI works again