### PR TITLE
Updates and cleanups

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,16 +103,15 @@
     },
     "haskell-nix": {
       "locked": {
-        "lastModified": 1604670513,
-        "narHash": "sha256-ir7WUoKjN/RUm7xk73K1GKUREui7pXWWgIHYTrqSxPs=",
+        "lastModified": 1612789116,
+        "narHash": "sha256-l12sDNsvsu9otmUzL6TIvFzx3n4zIjtWkfoqCDW/xTw=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ddc4d650fe668c84090ccc9e3ad6a5b82c6654f7",
+        "rev": "43513e406c0348f703be6f73a7a56c1c57c8ad41",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "update-flake",
         "repo": "haskell.nix",
         "type": "github"
       }
@@ -194,18 +193,14 @@
     "morpho-node": {
       "inputs": {
         "haskell-nix": "haskell-nix",
-        "nixpkgs": [
-          "morpho-node",
-          "haskell-nix"
-        ],
         "utils": "utils_4"
       },
       "locked": {
-        "lastModified": 1611853719,
-        "narHash": "sha256-JaBjm4lupDunk4iAHjiq49hHOIQv9dA8ujtsX64+2Zo=",
+        "lastModified": 1612807773,
+        "narHash": "sha256-wL/MnASkuEfJpLyOWLkVOQe2JcHc37Hv9R27DRpbVaw=",
         "owner": "input-output-hk",
         "repo": "ECIP-Checkpointing",
-        "rev": "72f7c3136b73718695c94a0a874e94c4bc61203e",
+        "rev": "4de0b3888642945aacf5b5eba874e5b6f1a5f6be",
         "type": "github"
       },
       "original": {

--- a/jobs/mantis-staging.nix
+++ b/jobs/mantis-staging.nix
@@ -33,7 +33,9 @@ let
 
   mkMantis = { name, resources, count ? 1, templates, serviceName, tags ? [ ]
     , serverMeta ? { }, meta ? { }, discoveryMeta ? { }, requiredPeerCount
-    , services ? { } }: {
+    , services ? { } }:
+    let fullName = name + lib.optionalString (count > 1) "-\${NOMAD_ALLOC_INDEX}";
+    in {
       inherit count;
 
       networks = [{
@@ -93,7 +95,7 @@ let
             omit_hostname = false
 
             [global_tags]
-            client_id = "${name}"
+            client_id = "${fullName}"
             namespace = "${namespace}"
 
             [inputs.prometheus]
@@ -172,7 +174,7 @@ let
           logging = {
             type = "journald";
             config = [{
-              tag = name;
+              tag = fullName;
               labels = "name,namespace,imageTag";
             }];
           };
@@ -294,8 +296,8 @@ let
       };
     });
 
-  mkPassive = count:
-    let name = "${namespace}-mantis-passive";
+  mkPassive = nameSuffix: count:
+    let name = "mantis${lib.optionalString (nameSuffix != null) "-${nameSuffix}"}-passive";
     in mkMantis {
       inherit name;
       serviceName = name;
@@ -921,7 +923,7 @@ in {
 
     taskGroups = let
       minerTaskGroups = lib.listToAttrs (map mkMiner miners);
-      passiveTaskGroups = { passive = mkPassive 3; };
+      passiveTaskGroups = { passive = mkPassive null 3; };
     in minerTaskGroups // passiveTaskGroups;
   };
 
@@ -935,7 +937,7 @@ in {
     taskGroups = let
       mkMorpho = import ./tasks/morpho.nix;
       generateMorphoTaskGroup = nbNodes: node:
-        lib.nameValuePair node.name (lib.recursiveUpdate (mkPassive 1)
+        lib.nameValuePair node.name (lib.recursiveUpdate (mkPassive node.name 1)
           (mkMorpho (node // { inherit lib nbNodes; })));
       morphoTaskGroups =
         map (generateMorphoTaskGroup (builtins.length morphoNodes)) morphoNodes;

--- a/overlay.nix
+++ b/overlay.nix
@@ -54,7 +54,7 @@ in {
   };
   morpho-source = self.inputs.morpho-node;
 
-  morpho-node = self.inputs.morpho-node.morpho-node.${system};
+  morpho-node = self.inputs.morpho-node.defaultPackage.${system};
 
   # Any:
   # - run of this command with a parameter different than the testnet (currently 10)

--- a/overlay.nix
+++ b/overlay.nix
@@ -29,7 +29,7 @@ in {
 
   mantis-staging-source = builtins.fetchGit {
     url = "https://github.com/input-output-hk/mantis";
-    rev = "dac4214e78cf0ed103f2194accf9f5a1e44d6062";
+    rev = "427d8e8ef30f1038b33719f1e0fa50a8352c33c4";
     ref = "develop";
     submodules = true;
   };
@@ -45,7 +45,10 @@ in {
 
   mantis = import final.mantis-source { inherit system; };
 
-  mantis-staging = import final.mantis-staging-source { inherit system; };
+  mantis-staging = import final.mantis-staging-source {
+    src = final.mantis-staging-source;
+    inherit system;
+  };
 
   mantis-faucet = import final.mantis-faucet-source { inherit system; };
 


### PR DESCRIPTION
- Makes grafana and loki distinguish between all passive nodes.
- Cleans up the morpho nomad definition
- Updates morpho to the latest master version, which notably includes https://github.com/input-output-hk/ECIP-Checkpointing/pull/16, which as a side effect allows mantis-ops to reuse the hydra.mantis.ist caches for morpho
- Updates mantis to the latest develop version