### PR TITLE
wip README update after cue changes

### DIFF
--- a/clusters/mantis/testnet/nix.nix
+++ b/clusters/mantis/testnet/nix.nix
@@ -1,13 +1,11 @@
 { ... }: {
   nix = {
     binaryCaches = [
-      "https://vit-ops.cachix.org"
       "https://hydra.iohk.io"
       "https://hydra.mantis.ist"
     ];
 
     binaryCachePublicKeys = [
-      "vit-ops.cachix.org-1:LY84nIKdW7g1cvhJ6LsupHmGtGcKAlUXo+l1KByoDho="
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "hydra.mantis.ist-1:4LTe7Q+5pm8+HawKxvmn2Hx0E3NbkYjtf1oWv+eAmTo="
     ];

--- a/nix-in-docker/nix.conf
+++ b/nix-in-docker/nix.conf
@@ -1,4 +1,4 @@
 sandbox = false
 experimental-features = nix-command flakes ca-references
-substituters = https://hydra.iohk.io https://cache.nixos.org https://mantis-ops.cachix.org https://hydra.mantis.ist
-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= mantis-ops.cachix.org-1:SornDcX8/9rFrpTjU+mAAb26sF8mUpnxgXNjmKGcglQ= hydra.mantis.ist-1:4LTe7Q+5pm8+HawKxvmn2Hx0E3NbkYjtf1oWv+eAmTo=
+substituters = https://hydra.iohk.io https://cache.nixos.org https://hydra.mantis.ist
+trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=  hydra.mantis.ist-1:4LTe7Q+5pm8+HawKxvmn2Hx0E3NbkYjtf1oWv+eAmTo=


### PR DESCRIPTION
I'm sure @input-output-hk/mantis-devs would like to know how to deploy nomad jobs after the recent cue changes. README.md work may take a bit longer to update all the relevant bits, but information on how to deploy has been [updated](https://github.com/input-output-hk/mantis-ops/tree/doc-update#deployment-running-a-mantis-job) at least.