### PR TITLE
ETCM-769: fine-tuned control of logback.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,32 @@ mkdir -p /var/tmp
   "Versions" section for a given namespace, e.g. the [mantis-testnet
 versions](https://nomad.mantis.ws/ui/jobs/miner/versions?namespace=mantis-testnet).
 
+### Debugging Mantis Nodes
+
+It is possible to set the logging level for individual classes in order to assist in debugging without flooding the logs with irrelevant detail.
+
+To get started, open up the `deploy.cue` file, and look for the `#loggers` set under `vars`.
+
+The default values are given for the sake of example. You can either add your own classes: `"CLASSNAME": "LOGLEVEL"`, or modify the existing values to the desired level. The special value `"${LOGLEVEL}"` refers to the global `logging.logs-level` setting.
+
+#### Global logging
+
+If you wish set the global logging level for all namespaces, simply open the `deploy.cue` file and change `#logLevel`, where the `*` designates the default value if unset elsewhere.
+
+If you only want it on for a particular Nomad namespace, you can set `#logLevel` to the appropriate value under a given namespace's `vars` in `deploy.cue`:
+```cue
+#namespaces: {
+  // ...
+  "mantis-staging": {
+      vars: {
+        #logLevel: "DEBUG"
+        // other vars ...
+      }
+      // ...
+  }
+}
+```
+
 ### Nix Repl For Exploring Nix Attributes
 
 * Nix repl can be used for finding nix attributes by entering a nix repl environment:

--- a/deploy.cue
+++ b/deploy.cue
@@ -86,6 +86,21 @@ _Namespace: [Name=_]: {
 		  \(strings.Join(#bootstrapNodes[Name], ",\n"))
 		]
 		"""
+		#logLevel:      "TRACE" | "DEBUG" | *"INFO" | "WARN" | "ERROR" | "OFF"
+		let #logType = #logLevel | "${LOGSLEVEL}"
+
+		// specify a unique loglevel for a given object; passed to logback.xml
+		#loggers: {[string]: #logType} & {
+			"io.netty":                                            "WARN"
+			"io.iohk.scalanet":                                    "INFO"
+			"io.iohk.ethereum.blockchain.sync.SyncController":     "INFO"
+			"io.iohk.ethereum.network.PeerActor":                  "${LOGSLEVEL}"
+			"io.iohk.ethereum.network.rlpx.RLPxConnectionHandler": "${LOGSLEVEL}"
+			"io.iohk.ethereum.vm.VM":                              "OFF"
+			"org.jupnp.QueueingThreadPoolExecutor":                "WARN"
+			"org.jupnp.util.SpecificationViolationReporter":       "ERROR"
+			"org.jupnp.protocol.RetrieveRemoteDescriptors":        "ERROR"
+		}
 	}
 	jobs: [string]: types.#stanza.job
 }

--- a/jobs/mantis.cue
+++ b/jobs/mantis.cue
@@ -6,13 +6,21 @@ import (
 )
 
 #Mantis: types.#stanza.job & {
-	#count:         uint | *5
-	#role:          "passive" | "miner" | "backup"
-	#mantisRev:     string
-	#fqdn:          string
+	#count:     uint | *5
+	#role:      "passive" | "miner" | "backup"
+	#logLevel:  string
+	#mantisRev: string
+	#fqdn:      string
+	#loggers: {[string]: string}
 	#networkConfig: string
 
-	let ref = {networkConfig: #networkConfig, mantisRev: #mantisRev, role: #role}
+	let ref = {
+		networkConfig: #networkConfig
+		mantisRev:     #mantisRev
+		role:          #role
+		logLevel:      #logLevel
+		loggers:       #loggers
+	}
 
 	namespace: string
 	type:      "service"
@@ -62,7 +70,9 @@ import (
 			#namespace:     namespace
 			#mantisRev:     ref.mantisRev
 			#role:          ref.role
+			#logLevel:      ref.logLevel
 			#networkConfig: ref.networkConfig
+			#loggers:       ref.loggers
 		}
 
 		task: promtail: tasks.#Promtail

--- a/jobs/morpho.cue
+++ b/jobs/morpho.cue
@@ -84,6 +84,7 @@ import (
 			#namespace:     namespace
 			#mantisRev:     ref.mantisRev
 			#role:          "passive"
+			#logLevel:      "INFO"
 			#networkConfig: ref.networkConfig
 		}
 	}

--- a/jobs/tasks/morpho.cue
+++ b/jobs/tasks/morpho.cue
@@ -28,7 +28,7 @@ import (
 	config: {
 		flake:   "github:input-output-hk/ECIP-Checkpointing?rev=\(#morphoRev)#morpho"
 		command: "/bin/morpho-checkpoint-node"
-		args: [ "--config", "/local/morpho-config.yaml" ]
+		args: [ "--config", "/local/morpho-config.yaml"]
 	}
 
 	restart_policy: {

--- a/jobs/tasks/promtail.cue
+++ b/jobs/tasks/promtail.cue
@@ -44,7 +44,7 @@ import (
 						nomad_region:        "{{ env \"NOMAD_REGION\" }}"
 						// This is currently always "promtail", so this label wouldn't be of any use
 						// nomad_task_name:     "{{ env \"NOMAD_TASK_NAME\" }}"
-						"__path__":          "/alloc/logs/*.std*.[0-9]*"
+						"__path__": "/alloc/logs/*.std*.[0-9]*"
 					}
 				}]
 			}]


### PR DESCRIPTION
These changes allow users to set the log level for a particular Scala class in the `deploy.cue` file. Instructions are layed out in the [README.md](https://github.com/input-output-hk/mantis-ops/tree/loglevel-switch#debugging-mantis-nodes).