### PR TITLE
Fix configuration to allow redeployment of passive nodes in staging

### DIFF
--- a/deploy.cue
+++ b/deploy.cue
@@ -18,6 +18,7 @@ import (
 	}
 	"mantis-staging": jobs: {
 		miner: #miner
+		passive: #passive & {#count: 1}
 	}
 	"mantis-e2e": jobs: {
 		miner:    #e2eMiner


### PR DESCRIPTION
Passive nodes were enabled again in Staging, but deploy.cue was not updated accordingly to allow the redeployment