### PR TITLE
add revant caches directly to the flake for more encapsulation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,9 @@
 {
   description = "Bitte for Mantis";
 
+  nixConfig.extra-substituters = "https://hydra.iohk.io https://hydra.mantis.ist";
+  nixConfig.extra-trusted-public-keys = "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= hydra.mantis.ist-1:4LTe7Q+5pm8+HawKxvmn2Hx0E3NbkYjtf1oWv+eAmTo=";
+
   inputs = {
     bitte.url = "github:input-output-hk/bitte";
     nixpkgs.follows = "bitte/nixpkgs";


### PR DESCRIPTION
this works on recent `nix` as of aprox. https://github.com/NixOS/nix/commit/9a586e34ac3ae37bfd18f4e82af26df938ab9d96
